### PR TITLE
Prevent extra `resource.emitAfter()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = (schema, options) => {
         args.unshift(callback, null);
         if (resource.runInAsyncScope) {
           resource.runInAsyncScope.apply(resource, args);
+          emittedAfter = true;
           return;
         }
 


### PR DESCRIPTION
when the line `resource.runInAsyncScope.apply(resource, args);` throws error, a `resource.emitAfter()` will be called in the catch block, which may introduce an unexpected error.