### PR TITLE
Fix another mistake.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ module.exports = (schema, options) => {
       let emittedAfter = false;
       const args = Array.prototype.slice.call(arguments, 0);
       try {
-        args.unshift(callback, null);
         if (resource.runInAsyncScope) {
           emittedAfter = true;
+          args.unshift(callback, null);
           resource.runInAsyncScope.apply(resource, args);
           return;
         }


### PR DESCRIPTION
`args.unshift(callback, null)` should be called only when `resource.runInAsyncScope` exists. Sorry I've never checked this with node <9.6.0 env before.